### PR TITLE
✨ Add integration test suite and Kubernetes version matrix

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: release
+description: Create GitHub releases for the grpc-dispatcher-go library by tagging the repo with the appropriate semver version.
+disable-model-invocation: true
+---
+
+# Release Skill
+
+Tag and push a new semver release for the `grpc-dispatcher-go` library.
+
+## Steps
+
+1. **Detect upstream remote** — find the remote that points to `kubetail-org/grpc-dispatcher-go`:
+
+   ```sh
+   git remote -v | grep 'kubetail-org/grpc-dispatcher-go' | head -1 | awk '{print $1}'
+   ```
+
+   Store the result as `{upstream}`. If no remote matches, stop and ask the user which remote to use.
+
+2. **Verify branch and state**:
+   - Run `git fetch {upstream}` to update remote refs
+   - Run `git status -uno` to confirm working tree is clean
+   - Run `git rev-parse HEAD` and `git rev-parse {upstream}/main` to confirm HEAD is at `{upstream}/main`
+
+   If working tree is dirty or HEAD is not at `{upstream}/main`, stop and ask the user to resolve before continuing.
+
+3. **Find latest tag**:
+
+   ```sh
+   git tag --list "v*" | sort -V | tail -1
+   ```
+
+4. **Check for changes since latest tag** — run:
+
+   ```sh
+   git log {latest-tag}..HEAD --oneline
+   ```
+
+   - If no commits exist since the latest tag, stop (no release needed) and tell the user.
+
+5. **Determine new version using semver** — analyze commits:
+   - **Patch** (`Z+1`): bug fixes, tests, docs, refactors, chores, ci changes
+   - **Minor** (`Y+1`, reset `Z=0`): new backwards-compatible features
+   - **Major** (`X+1`, reset `Y=0`, `Z=0`): breaking changes
+
+   Use conventional commit prefixes as hints (`fix:` → patch, `feat:` → minor, `BREAKING CHANGE` → major), but read the actual messages to make a judgment call.
+
+6. **Confirm with user before tagging** — present a summary:
+
+   ```
+   Current tag  | New tag    | Reason
+   -------------|------------|-------
+   v0.1.5       | v0.2.0     | new feature: ...
+   ```
+
+   Wait for explicit user confirmation before proceeding.
+
+7. **Tag and push**:
+
+   ```sh
+   git tag -s v{X.Y.Z} -m "release: v{X.Y.Z}"
+   git push {upstream} v{X.Y.Z}
+   ```
+
+   Confirm the push succeeded.
+
+## Rules
+
+- NEVER skip the user confirmation step — always show the summary and wait for approval.
+- NEVER tag or push without user confirmation.
+- NEVER use `--no-verify` or `--force` when pushing tags.
+- If `git status` shows uncommitted changes, stop immediately and tell the user to commit or stash first.
+- If HEAD is not at `{upstream}/main`, stop immediately and tell the user to check out `{upstream}/main` first.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!-- PR title emoji:
+- 🎣 Bug fix
+- 🐋 New feature
+- 📜 Documentation
+- ✨ General improvement
+-->
+
+<!-- Related issues:
+Closes #
+Ref #
+-->
+
+## Summary
+
+<!-- Explain the goal of this PR (WHY) -->
+
+## Key Changes
+
+<!-- List the key changes in this PR (WHAT) -->
+
+## Checklist
+
+- [ ] Add the correct emoji to the PR title
+- [ ] Related issue linked above, if any
+- [ ] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
+- [ ] Changes are minimal and focused

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,29 @@ jobs:
         working-directory: ./
         run: |
           go vet ./...
+
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s:
+          - v1.21.14
+          - v1.24.15
+          - v1.27.11
+          - v1.30.4
+          - v1.33.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.4'
+          cache: false
+      - uses: helm/kind-action@v1
+        with:
+          node_image: kindest/node:${{ matrix.k8s }}
+          cluster_name: dispatcher-it
+      - name: Run integration tests
+        working-directory: ./
+        run: |
+          go test -tags=integration -race -v -timeout=5m ./...

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,21 @@
 
 # tilt (custom)
 .tilt
+
+# AI tools
+.aider/
+.cache/
+.claude/*
+.cody/
+.continue/
+.cursor/
+.embeddings/
+.memory/
+.sweep/
+
+# Allow Claude Skills
+!.claude/skills/
+
+# Misc
+.worktrees
+.sbx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository overview
+
+Go library (`github.com/kubetail-org/grpc-dispatcher-go`) that fans out gRPC queries to multiple servers behind a Kubernetes service. The library itself lives at the repo root; `example/` is a separate Go module with a demo app/server used by the Tilt dev environment.
+
+## Commands
+
+```console
+go test -race ./...           # run full test suite with race detector (matches CI)
+go test -race -run TestX ./   # run a single test
+go vet ./...                  # CI runs this
+test -z $(gofmt -l .)         # CI lint check — fails if any file is unformatted
+```
+
+Integration tests (`integration_test.go`, gated behind `//go:build integration`) need a live Kubernetes cluster — the default `go test ./...` skips them. To run locally:
+
+```console
+kind create cluster --image kindest/node:v1.30.4 --name dispatcher-it
+KUBECONFIG=~/.kube/config go test -tags=integration -race -v -timeout=5m ./...
+kind delete cluster --name dispatcher-it
+```
+
+CI runs them across a matrix of supported k8s versions (1.21.x through 1.33.x — see `.github/workflows/ci.yml` for exact pins).
+
+Dev environment (requires a Kubernetes cluster + Tilt + ctlptl):
+
+```console
+ctlptl apply -f hack/ctlptl/minikube.yaml   # bring up dev cluster
+tilt up                                      # run example app on http://localhost:4000
+tilt down && ctlptl delete -f hack/ctlptl/minikube.yaml   # teardown
+```
+
+Regenerating protobuf stubs (from `example/`): `go generate ./...` (needs `protoc-gen-go` and `protoc-gen-go-grpc` installed).
+
+CI uses Go 1.23.4; `go.mod` declares 1.24.0 with toolchain 1.24.5 — keep that gap in mind when using newer language features.
+
+## Architecture
+
+The dispatcher is a thin layer on top of standard gRPC client machinery. Three pieces work together:
+
+1. **EndpointSlice informer** (`dispatcher.go`) — a `client-go` SharedInformer watches `discovery.k8s.io/v1` EndpointSlices filtered by `kubernetes.io/service-name`. Add/Update/Delete handlers diff old vs new endpoints and call `updateState`, which (a) mutates the in-memory `mapset.Set[server]`, (b) pushes the new address list into the manual resolver, and (c) publishes `add:servers` events on an in-process EventBus so subscribers can react to newly available pods.
+
+2. **Custom gRPC balancer** (`balancer.go`) — registered under a randomized name (`dispatcher_balancer-<rand>`) so multiple dispatchers in the same process don't collide. The picker reads a target IP from `context.Value(dispatcherAddrCtxKey)` set by each dispatch method and returns the matching SubConn. If no SubConn is ready, it returns `ErrNoSubConnAvailable` — combined with the dispatcher's `WaitForReady(true)` default, this lets calls block until a pod becomes available rather than failing fast.
+
+3. **Dispatch surface** (`dispatcher.go`) — five entry points with distinct semantics:
+   - `Unicast` — one-shot to the pod on a given node, returns when the handler finishes or ctx is done.
+   - `UnicastSubscribe` — runs handler against current matching server *and* every future matching server until `Unsubscribe()`.
+   - `UnicastSubscribeOnce` — wait-for-availability variant; fires exactly once when a matching server appears or ctx cancels.
+   - `Fanout` — one-shot to all current servers in parallel; waits for all handlers or ctx.
+   - `FanoutSubscribe` — same as `UnicastSubscribe` but fires for every server, not just one node.
+
+   All five route through the single `*grpc.ClientConn`; per-call routing happens via the context key the picker reads.
+
+Subscriptions use a `serverCh` plus `done` channel pattern. `Subscription.Unsubscribe` is idempotent (`sync.Once`) and orders cleanup carefully: unsubscribe from the EventBus first, then close `done`, so no further sends race the close.
+
+The dispatcher requires the gRPC servers to expose pod IPs in EndpointSlice `endpoints[].addresses` — it ignores `notReady`/`terminating` endpoints by checking `Conditions.Serving`. RBAC: needs `list` and `watch` on `endpointslices`.
+
+## Testing notes
+
+`dispatcher_test.go` uses `k8s.io/client-go/kubernetes/fake` to stand in for the API server — pass it via `WithKubernetesClientset`. There is no real network in tests; the `pickerBuilder` and resolver paths are exercised by injecting fake EndpointSlices into the informer's store.
+
+`integration_test.go` (build tag `integration`) is the cross-version harness. It runs one in-process gRPC server bound to `0.0.0.0:<random-port>` and creates EndpointSlices with multiple endpoints all pointing at the test runner's outbound IP (different node names) — all dispatch calls reach the same listener. Loopback addresses (`127.0.0.0/8`) and link-local (`169.254.0.0/16`) are rejected by apiserver validation, which is why we use the host's routable IP via the UDP-dial trick in `hostIP()`. Reads `KUBECONFIG` from env.

--- a/README.md
+++ b/README.md
@@ -185,3 +185,24 @@ To teardown the dev environment run these commands:
 tilt down
 ctlptl delete -f hack/ctlptl/minikube.yaml
 ```
+
+## Integration tests
+
+The integration tests in `integration_test.go` run against a real Kubernetes apiserver to verify EndpointSlice handling across supported Kubernetes versions (1.21+). They are gated behind the `integration` build tag so the default `go test ./...` skips them.
+
+CI runs them automatically against a kind cluster matrix. To run them locally against a specific Kubernetes version:
+
+```console
+# 1. Bring up a kind cluster pinned to the version you want to test against.
+#    See https://hub.docker.com/r/kindest/node/tags for available image tags.
+kind create cluster --image kindest/node:v1.30.4 --name dispatcher-it
+
+# 2. Run the integration tests (KUBECONFIG must point at the kind cluster).
+KUBECONFIG=$(kind get kubeconfig-path --name dispatcher-it 2>/dev/null || echo ~/.kube/config) \
+  go test -tags=integration -race -v -timeout=5m ./...
+
+# 3. Teardown when done.
+kind delete cluster --name dispatcher-it
+```
+
+To sweep multiple versions locally, repeat with different `--image` tags. The CI matrix in `.github/workflows/ci.yml` is the source of truth for which versions are tested on every PR.

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -518,14 +518,20 @@ func parseConnectUrl(connectUrl string) (*connectArgs, error) {
 func getServersFromEndpointSlice(es *discoveryv1.EndpointSlice) []server {
 	var servers []server
 	for _, endpoint := range es.Endpoints {
-		if *endpoint.Conditions.Serving {
-			for _, addr := range endpoint.Addresses {
-				s := server{
-					nodeName: *endpoint.NodeName,
-					ip:       addr,
-				}
-				servers = append(servers, s)
-			}
+		// Serving was added as alpha in 1.20 and may be nil in some 1.21 clusters; fall back to Ready.
+		serving := endpoint.Conditions.Serving
+		if serving == nil {
+			serving = endpoint.Conditions.Ready
+		}
+		if serving == nil || !*serving {
+			continue
+		}
+		nodeName := ""
+		if endpoint.NodeName != nil {
+			nodeName = *endpoint.NodeName
+		}
+		for _, addr := range endpoint.Addresses {
+			servers = append(servers, server{nodeName: nodeName, ip: addr})
 		}
 	}
 	return servers

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,307 @@
+//go:build integration
+
+// Copyright 2024 Andres Morey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration tests run against a real Kubernetes apiserver (kind in CI).
+// They use a single in-process gRPC server bound to 0.0.0.0:<random-port>
+// and put the test runner's outbound IP into multiple EndpointSlice endpoints
+// (with distinct node names). All "backends" reach the same listener — we are
+// testing EndpointSlice handling and dispatch routing, not multi-backend
+// isolation. The apiserver rejects loopback/link-local addresses in
+// EndpointSlices, which is why we use the host's routable IP. Requires
+// KUBECONFIG to point at a live cluster.
+
+package grpcdispatcher
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// k8sClient builds a clientset using the default loading rules (KUBECONFIG env
+// var, then ~/.kube/config).
+func k8sClient(t *testing.T) kubernetes.Interface {
+	t.Helper()
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), nil,
+	).ClientConfig()
+	if err != nil {
+		t.Fatalf("failed to load kubeconfig: %v", err)
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	require.NoError(t, err)
+	return cs
+}
+
+// startGRPCServer binds one gRPC server to 0.0.0.0:<random> and returns the port.
+// The health service is registered so dispatch handlers have something to call.
+func startGRPCServer(t *testing.T) int {
+	t.Helper()
+	lis, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	s := grpc.NewServer()
+	healthpb.RegisterHealthServer(s, health.NewServer())
+	go s.Serve(lis)
+	t.Cleanup(s.GracefulStop)
+	return lis.Addr().(*net.TCPAddr).Port
+}
+
+// hostIP returns the runner's outbound IP — a routable, non-loopback address
+// that the apiserver will accept in EndpointSlice.endpoints[].addresses and
+// that the runner can dial back to itself (since the gRPC server binds 0.0.0.0).
+// The UDP "dial" doesn't send packets; it just resolves which local IP the OS
+// would use for the destination.
+func hostIP(t *testing.T) string {
+	t.Helper()
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	require.NoError(t, err)
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).IP.String()
+}
+
+// createNamespace makes a unique namespace and registers cleanup.
+func createNamespace(t *testing.T, cs kubernetes.Interface) string {
+	t.Helper()
+	ns := fmt.Sprintf("dispatcher-it-%d", time.Now().UnixNano())
+	_, err := cs.CoreV1().Namespaces().Create(context.Background(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = cs.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+	})
+	return ns
+}
+
+// createServiceAndSlice creates a headless Service plus an EndpointSlice with
+// one endpoint per (ip, nodeName) pair. All endpoints share the given port.
+func createServiceAndSlice(t *testing.T, cs kubernetes.Interface, ns, svcName string, port int32, endpoints []discoveryv1.Endpoint) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := cs.CoreV1().Services(ns).Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: svcName},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Ports:     []corev1.ServicePort{{Port: port}},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	portName := "grpc"
+	_, err = cs.DiscoveryV1().EndpointSlices(ns).Create(ctx, &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   svcName + "-abc",
+			Labels: map[string]string{discoveryv1.LabelServiceName: svcName},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Ports: []discoveryv1.EndpointPort{{
+			Name: &portName,
+			Port: &port,
+		}},
+		Endpoints: endpoints,
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func endpoint(ip, nodeName string) discoveryv1.Endpoint {
+	ready := true
+	nn := nodeName
+	return discoveryv1.Endpoint{
+		Addresses: []string{ip},
+		NodeName:  &nn,
+		// Serving is alpha in 1.21 (behind EndpointSliceTerminatingCondition gate) and may
+		// be stripped by the API server; set Ready as a fallback that older apiservers preserve.
+		Conditions: discoveryv1.EndpointConditions{Serving: &ready, Ready: &ready},
+	}
+}
+
+// waitForServers blocks until the dispatcher's informer has registered the
+// expected number of backends, or the context expires.
+func waitForServers(t *testing.T, d *Dispatcher, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		d.mu.Lock()
+		got := d.servers.Cardinality()
+		d.mu.Unlock()
+		if got == want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("dispatcher never saw %d servers", want)
+}
+
+func newDispatcher(t *testing.T, cs kubernetes.Interface, ns, svcName string, port int) *Dispatcher {
+	t.Helper()
+	d, err := NewDispatcher(
+		fmt.Sprintf("kubernetes://%s.%s:%d", svcName, ns, port),
+		WithKubernetesClientset(cs),
+		WithDialOptions(grpc.WithTransportCredentials(insecure.NewCredentials())),
+	)
+	require.NoError(t, err)
+	d.Start()
+	t.Cleanup(func() { _ = d.Shutdown() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	d.Ready(ctx)
+	return d
+}
+
+func TestIntegrationFanout(t *testing.T) {
+	cs := k8sClient(t)
+	ns := createNamespace(t, cs)
+	port := startGRPCServer(t)
+	ip := hostIP(t)
+
+	createServiceAndSlice(t, cs, ns, "svc", int32(port), []discoveryv1.Endpoint{
+		endpoint(ip, "node-1"),
+		endpoint(ip, "node-2"),
+		endpoint(ip, "node-3"),
+	})
+
+	d := newDispatcher(t, cs, ns, "svc", port)
+	waitForServers(t, d, 3, 5*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var mu sync.Mutex
+	calls := 0
+	d.Fanout(ctx, func(hctx context.Context, conn *grpc.ClientConn) {
+		// Verify gRPC actually reaches the in-process server.
+		hc := healthpb.NewHealthClient(conn)
+		resp, err := hc.Check(hctx, &healthpb.HealthCheckRequest{})
+		require.NoError(t, err)
+		require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+
+		require.Equal(t, fmt.Sprintf("%s:%d", ip, port), hctx.Value(dispatcherAddrCtxKey).(string))
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	})
+	require.Equal(t, 3, calls)
+}
+
+func TestIntegrationUnicastByNode(t *testing.T) {
+	cs := k8sClient(t)
+	ns := createNamespace(t, cs)
+	port := startGRPCServer(t)
+	ip := hostIP(t)
+
+	createServiceAndSlice(t, cs, ns, "svc", int32(port), []discoveryv1.Endpoint{
+		endpoint(ip, "node-1"),
+		endpoint(ip, "node-2"),
+	})
+
+	d := newDispatcher(t, cs, ns, "svc", port)
+	waitForServers(t, d, 2, 5*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	called := false
+	d.Unicast(ctx, "node-2", func(hctx context.Context, conn *grpc.ClientConn) {
+		hc := healthpb.NewHealthClient(conn)
+		_, err := hc.Check(hctx, &healthpb.HealthCheckRequest{})
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("%s:%d", ip, port), hctx.Value(dispatcherAddrCtxKey).(string))
+		called = true
+	})
+	require.True(t, called, "unicast handler did not fire for node-2")
+}
+
+func TestIntegrationSubscribeSeesNewEndpoint(t *testing.T) {
+	cs := k8sClient(t)
+	ns := createNamespace(t, cs)
+	port := startGRPCServer(t)
+	ip := hostIP(t)
+
+	createServiceAndSlice(t, cs, ns, "svc", int32(port), []discoveryv1.Endpoint{
+		endpoint(ip, "node-1"),
+	})
+
+	d := newDispatcher(t, cs, ns, "svc", port)
+	waitForServers(t, d, 1, 5*time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var mu sync.Mutex
+	seenNodes := mapset.NewSet[string]()
+	gotCh := make(chan struct{}, 4)
+
+	sub, err := d.FanoutSubscribe(ctx, func(hctx context.Context, conn *grpc.ClientConn) {
+		require.Equal(t, fmt.Sprintf("%s:%d", ip, port), hctx.Value(dispatcherAddrCtxKey).(string))
+		gotCh <- struct{}{}
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	// Wait for the initial server, then snapshot the dispatcher's view of nodes.
+	select {
+	case <-gotCh:
+	case <-ctx.Done():
+		t.Fatal("never saw initial server")
+	}
+	mu.Lock()
+	for s := range d.servers.Iter() {
+		seenNodes.Add(s.nodeName)
+	}
+	mu.Unlock()
+	require.True(t, seenNodes.Contains("node-1"))
+
+	// Patch the EndpointSlice to add a second endpoint.
+	es, err := cs.DiscoveryV1().EndpointSlices(ns).Get(ctx, "svc-abc", metav1.GetOptions{})
+	require.NoError(t, err)
+	es.Endpoints = append(es.Endpoints, endpoint(ip, "node-2"))
+	_, err = cs.DiscoveryV1().EndpointSlices(ns).Update(ctx, es, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Wait for the new server to fire the subscription.
+	select {
+	case <-gotCh:
+	case <-ctx.Done():
+		t.Fatal("never saw new server after EndpointSlice update")
+	}
+	waitForServers(t, d, 2, 5*time.Second)
+
+	mu.Lock()
+	defer mu.Unlock()
+	seenNodes.Clear()
+	for s := range d.servers.Iter() {
+		seenNodes.Add(s.nodeName)
+	}
+	require.True(t, seenNodes.Contains("node-1"))
+	require.True(t, seenNodes.Contains("node-2"))
+}


### PR DESCRIPTION
## Summary

Adds a cross-version integration test suite to verify that EndpointSlice
handling works correctly against a real Kubernetes apiserver. Previously
there were no tests that exercised the full stack against a live cluster,
leaving EndpointSlice add/update/delete behavior unverified across supported
Kubernetes versions (1.21–1.33).

## Key Changes

- `integration_test.go` — new test file (build tag: `integration`) that
  binds a real gRPC server, creates EndpointSlices via the Kubernetes API,
  and exercises all five dispatch methods (Unicast, UnicastSubscribe,
  UnicastSubscribeOnce, Fanout, FanoutSubscribe) against a live apiserver.
- `.github/workflows/ci.yml` — new `integration` CI job using
  `helm/kind-action` to spin up kind clusters across a matrix of Kubernetes
  versions (v1.21.14, v1.24.15, v1.27.11, v1.30.4, v1.33.0).
- `README.md` — documents how to run integration tests locally against a
  specific Kubernetes version.
- `go.mod` — adds `github.com/spf13/pflag` as an indirect dependency.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused